### PR TITLE
Add support for inline tags (fixes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3 - 2026-02-15
+
+- Add support for inline tags
+
 ## 1.1.2 - 2026-01-21
 
 - Version bump and packaging for release.

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, Modal, App, Setting } from 'obsidian';
+import { Plugin, Modal, App, Setting, getAllTags } from 'obsidian';
 import { DEFAULT_SETTINGS, IndexNotesSettings, IndexNotesSettingTab } from 'src/settings/Settings';
 import { IndexUpdater } from 'src/indexer';
 import dateFormat from "dateformat";
@@ -114,8 +114,9 @@ export default class IndexNotesPlugin extends Plugin {
 
 		let metadata_cache = this.app.metadataCache.getCache(current_filepath);
 		let file_tags: string[] = [];
-		if (metadata_cache?.frontmatter?.tags) {
-			const tags = metadata_cache.frontmatter.tags;
+		if (metadata_cache) {
+			const regexHashtag = new RegExp(`^#`);
+			const tags = getAllTags(metadata_cache)?.map((tag) => tag.replace(regexHashtag, ""));
 			if (Array.isArray(tags)) {
 				file_tags = tags.filter(t => t && t !== this.settings.index_tag);
 			} else if (typeof tags === 'string') {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "index-notes",
 	"name": "Index Notes",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"minAppVersion": "0.15.0",
 	"description": "Keep your notes indexed based on their (hierarchical) tags",
 	"author": "Alejandro Daniel Noel",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.0.0",
+	"version": "1.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-sample-plugin",
-			"version": "1.0.0",
+			"version": "1.1.2",
 			"license": "MIT",
 			"dependencies": {
 				"dateformat": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-sample-plugin",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Automatically update index notes from your hierarchical tags!",
 	"main": "main.js",
 	"scripts": {


### PR DESCRIPTION
This is a small change to use `getAllTags` instead of the cached frontmatter tags. This uses Obsidian's built in tag management to use both frontmatter and inline tags.

Below example showing the changes:

#### Before:

<img width="852" height="358" alt="Screenshot 2026-02-15 at 1 58 05 AM" src="https://github.com/user-attachments/assets/950c74e6-2438-4b51-84a2-e6001f879966" />


#### After:

<img width="852" height="358" alt="Screenshot 2026-02-15 at 1 58 22 AM" src="https://github.com/user-attachments/assets/b2237f16-3b97-488d-aee7-a8f398e1efbd" />


